### PR TITLE
User middleware access token property

### DIFF
--- a/src/admin/middleware/admin.middleware.ts
+++ b/src/admin/middleware/admin.middleware.ts
@@ -17,6 +17,9 @@ export class AdminMiddleware implements NestMiddleware {
   ) {}
   async use(req: any, res: any, next: () => void) {
     //Funkcija za pridebitev osnovnih uporabnikovih podatkov
+    // Ensure req.body exists before setting properties
+    req.body = req.body || {};
+
     let authorization = await this.tokenService.verifyAuthHeader(
       req.headers.authorization,
     );

--- a/src/pass/middleware/doorPass.middleware.ts
+++ b/src/pass/middleware/doorPass.middleware.ts
@@ -12,6 +12,9 @@ export class DoorPassMiddleware implements NestMiddleware {
   private readonly logger = new Logger(DoorPassMiddleware.name);
   constructor(private readonly passService: PassService) {}
   async use(req: Request, res: Response, next: () => void) {
+    // Ensure req.body exists before setting properties
+    req.body = req.body || {};
+
     try {
       const accessSecret: string = req.headers['access_secret'] as string;
       const code: string = req.headers['door_code'] as string;

--- a/src/user/middleware/user.middleware.ts
+++ b/src/user/middleware/user.middleware.ts
@@ -13,6 +13,9 @@ export class UserMiddleware implements NestMiddleware {
 
   async use(req: Request, res: Response, next: NextFunction) {
     //Funkcija za pridebitev osnovnih uporabnikovih podatkov
+    // Ensure req.body exists before setting properties
+    req.body = req.body || {};
+
     const authorization = await this.tokenService.verifyAuthHeader(
       req.headers.authorization,
     );


### PR DESCRIPTION
Initialize `req.body` in middlewares to prevent `TypeError: Cannot set properties of undefined` when `req.body` is missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c7e8d98-bf2e-4578-b636-85b46497f650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c7e8d98-bf2e-4578-b636-85b46497f650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

